### PR TITLE
Add automated audio capture to audition runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ AUDITION_ONLY="bass_simple,soft_pad" make audition
 AUDITION_ONLY=all make audition
 ```
 
+### Audio capture
+
+- On macOS, each audition run now records the system output to a WAV file using `ffmpeg`.
+- The runner targets the `MacBook Pro Speakers` device (matching the SuperCollider session defaults) and writes recordings under `runner/runtime/recordings/`.
+- Set `AUDITION_CAPTURE_DEVICE` to override the output device name when a different aggregate/output is required. Leave the variable unset (or ensure it expands to an empty string) to disable capture.
+- If `ffmpeg` is not installed or the platform is not macOS, the runner automatically skips audio capture.
+
 ### Current state
 
 `runner/audition.scd` forces a 48 kHz session on the MacBook Pro speaker/mic pair, disables input buses for stability, and logs which SynthDefs were discovered. Build scripts still prioritize stock UGens; plugin-dependent definitions should provide fallbacks.

--- a/runner/run_audition.py
+++ b/runner/run_audition.py
@@ -2,9 +2,12 @@
 """Run the SuperCollider audition with a hard timeout safeguard."""
 
 import os
+import platform
+import shutil
 import signal
 import subprocess
 import sys
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
@@ -12,9 +15,11 @@ SCLANG = Path("/Applications/SuperCollider.app/Contents/MacOS/sclang")
 AUDITION_SCRIPT = (Path(__file__).resolve().parent / "audition.scd").resolve()
 AUDIO_CONF = (Path(__file__).resolve().parent / "sclang_conf.yaml").resolve()
 AUDIO_RUNTIME = (Path(__file__).resolve().parent / "runtime").resolve()
+AUDITION_CAPTURE_DIR = (AUDIO_RUNTIME / "recordings").resolve()
 REPO_ROOT = AUDITION_SCRIPT.parent.parent.resolve()
 SYNTHS_DIR = (REPO_ROOT / "synths").resolve()
 DEFAULT_TIMEOUT = 10.0
+DEFAULT_CAPTURE_DEVICE = "MacBook Pro Speakers"
 
 
 def _kill_processes(names: list[str]) -> None:
@@ -49,13 +54,129 @@ def _discover_default_target() -> Optional[str]:
     return None
 
 
+def _sanitize_capture_label(value: str) -> str:
+    cleaned = [c if c.isalnum() or c in {"-", "_"} else "-" for c in value]
+    label = "".join(cleaned).strip("-")
+    return label or "audition"
+
+
+def _start_audio_capture(env: dict[str, str], debug_mode: bool) -> tuple[Optional[subprocess.Popen], Optional[Path]]:
+    if platform.system() != "Darwin":
+        return (None, None)
+
+    capture_device = env.get("AUDITION_CAPTURE_DEVICE", DEFAULT_CAPTURE_DEVICE).strip()
+    if not capture_device:
+        if debug_mode:
+            print("[audition-runner] audio capture skipped: empty device name", flush=True)
+        return (None, None)
+
+    ffmpeg_path = shutil.which("ffmpeg")
+    if not ffmpeg_path:
+        if debug_mode:
+            print("[audition-runner] audio capture skipped: ffmpeg not found", flush=True)
+        return (None, None)
+
+    try:
+        AUDIO_RUNTIME.mkdir(parents=True, exist_ok=True)
+        AUDITION_CAPTURE_DIR.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        if debug_mode:
+            print(f"[audition-runner] audio capture skipped: unable to prepare directories ({exc})", flush=True)
+        return (None, None)
+
+    selection = env.get("AUDITION_ONLY", "all").strip() or "all"
+    label = _sanitize_capture_label(selection)
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    output_path = AUDITION_CAPTURE_DIR / f"{timestamp}-{label}.wav"
+
+    cmd = [
+        ffmpeg_path,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-nostdin",
+        "-y",
+        "-f",
+        "avfoundation",
+        "-i",
+        f":{capture_device}",
+        "-ac",
+        "2",
+        "-ar",
+        "48000",
+        "-c:a",
+        "pcm_s16le",
+        str(output_path),
+    ]
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        if debug_mode:
+            print("[audition-runner] audio capture skipped: ffmpeg executable missing", flush=True)
+        return (None, None)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        if debug_mode:
+            print(f"[audition-runner] audio capture failed to start: {exc}", flush=True)
+        return (None, None)
+
+    if debug_mode:
+        print(f"[audition-runner] capturing audio to {output_path}", flush=True)
+
+    return (proc, output_path)
+
+
+def _stop_audio_capture(
+    capture: tuple[Optional[subprocess.Popen], Optional[Path]],
+    debug_mode: bool,
+) -> None:
+    proc, output_path = capture
+    if proc is None:
+        return
+
+    try:
+        if proc.poll() is None:
+            try:
+                proc.send_signal(signal.SIGINT)
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=2)
+    finally:
+        stderr_output = b""
+        if proc.stderr is not None:
+            try:
+                stderr_output = proc.stderr.read()
+            finally:
+                proc.stderr.close()
+
+        if proc.returncode not in (0, None):
+            message = f"[audition-runner] audio capture exited with code {proc.returncode}"
+            if stderr_output:
+                message = f"{message}: {stderr_output.decode(errors='ignore').strip()}"
+            print(message, file=sys.stderr, flush=True)
+        elif output_path and output_path.exists():
+            print(f"[audition-runner] audio capture saved to {output_path}", flush=True)
+        elif debug_mode:
+            print("[audition-runner] audio capture produced no output", flush=True)
+
 def main() -> int:
     timeout = float(os.environ.get("AUDITION_TIMEOUT", DEFAULT_TIMEOUT))
     env = os.environ.copy()
     env["SC_AUDITION"] = "1"
     debug_mode = env.get("AUDITION_DEBUG")
+    debug_enabled = bool(debug_mode)
 
-    if debug_mode:
+    if debug_enabled:
         print("[audition-runner] debug mode enabled", flush=True)
 
     if not env.get("AUDITION_ONLY"):
@@ -65,6 +186,14 @@ def main() -> int:
             print(f"[audition-runner] defaulting to SynthDef '{target}'", flush=True)
 
     _kill_processes(["sclang", "scsynth"])
+
+    try:
+        AUDIO_RUNTIME.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        if debug_enabled:
+            print(f"[audition-runner] unable to ensure runtime directory: {exc}", flush=True)
+
+    capture = _start_audio_capture(env, debug_enabled)
 
     cmd = [
         str(SCLANG),
@@ -80,22 +209,28 @@ def main() -> int:
         proc = subprocess.Popen(cmd, env=env, preexec_fn=os.setsid)
     except FileNotFoundError:
         print(f"Could not find sclang executable at {SCLANG}", file=sys.stderr)
+        _stop_audio_capture(capture, debug_enabled)
         return 127
 
+    exit_code: int
     try:
-        return proc.wait(timeout=timeout)
+        exit_code = proc.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
         print(f"⚠️ Audition exceeded {timeout:.1f}s timeout; terminating SuperCollider session.", file=sys.stderr)
         _terminate_process_group(proc.pid, signal.SIGTERM)
         try:
-            return proc.wait(timeout=5)
+            exit_code = proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             _terminate_process_group(proc.pid, signal.SIGKILL)
             try:
-                return proc.wait(timeout=2)
+                exit_code = proc.wait(timeout=2)
             except subprocess.TimeoutExpired:
                 print("⚠️ Unable to fully terminate SuperCollider process tree.", file=sys.stderr)
-                return 124
+                exit_code = 124
+    finally:
+        _stop_audio_capture(capture, debug_enabled)
+
+    return exit_code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- spin up an ffmpeg capture alongside the audition runner on macOS and write WAV files under `runner/runtime/recordings`
- make the capture device configurable while still defaulting to the documented `MacBook Pro Speakers` output and ensure runtime directories exist
- document the automated capture workflow and override knob in the README

## Testing
- python -m compileall runner/run_audition.py

------
https://chatgpt.com/codex/tasks/task_e_68cdcea5f8a88330b9ef8aee6ec9ed5d